### PR TITLE
chore(gomall): remove go version from tidy script

### DIFF
--- a/gomall/scripts/tidy.sh
+++ b/gomall/scripts/tidy.sh
@@ -6,5 +6,5 @@ get_app_list
 
 readonly root_path=`pwd`
 for app_path in ${app_list[*]}; do
-    cd "${root_path}/${app_path}" &&  go mod tidy -go=1.23.0
+    cd "${root_path}/${app_path}" &&  go mod tidy 
 done

--- a/gomall/scripts/tidy.sh
+++ b/gomall/scripts/tidy.sh
@@ -6,5 +6,5 @@ get_app_list
 
 readonly root_path=`pwd`
 for app_path in ${app_list[*]}; do
-    cd "${root_path}/${app_path}" &&  go mod tidy -go=1.21
+    cd "${root_path}/${app_path}" &&  go mod tidy -go=1.23.0
 done


### PR DESCRIPTION
<img width="1507" height="378" alt="图片" src="https://github.com/user-attachments/assets/8e104295-ed24-4da8-810e-ee2ddb2a234f" />

解决go 版本未更新导致的幽灵错误
 fix go version error