### PR TITLE
fix: replace hardcoded credentials with env var functions (CWE-798)

### DIFF
--- a/easy_note/cmd/api/mw/jwt.go
+++ b/easy_note/cmd/api/mw/jwt.go
@@ -36,7 +36,7 @@ var JwtMiddleware *jwt.HertzJWTMiddleware
 
 func InitJWT() {
 	JwtMiddleware, _ = jwt.New(&jwt.HertzJWTMiddleware{
-		Key:           []byte(consts.SecretKey),
+		Key:           []byte(consts.SecretKey()),
 		TokenLookup:   "header: Authorization, query: token, cookie: jwt",
 		TokenHeadName: "Bearer",
 		TimeFunc:      time.Now,

--- a/easy_note/pkg/consts/consts.go
+++ b/easy_note/pkg/consts/consts.go
@@ -15,17 +15,17 @@
 
 package consts
 
+import "os"
+
 const (
 	NoteTableName   = "note"
 	UserTableName   = "user"
-	SecretKey       = "secret key"
 	IdentityKey     = "id"
 	Total           = "total"
 	Notes           = "notes"
 	ApiServiceName  = "demoapi"
 	NoteServiceName = "demonote"
 	UserServiceName = "demouser"
-	MySQLDefaultDSN = "gorm:gorm@tcp(localhost:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
 	TCP             = "tcp"
 	UserServiceAddr = ":9000"
 	NoteServiceAddr = ":10000"
@@ -33,3 +33,23 @@ const (
 	ETCDAddress     = "127.0.0.1:2379"
 	DefaultLimit    = 10
 )
+
+// SecretKey returns the JWT signing key from the JWT_SECRET_KEY environment variable.
+// Panics at startup if the variable is not set, preventing silent insecure defaults.
+func SecretKey() string {
+	key := os.Getenv("JWT_SECRET_KEY")
+	if key == "" {
+		panic("JWT_SECRET_KEY environment variable is required. Generate a strong random key.")
+	}
+	return key
+}
+
+// MySQLDSN returns the database connection string from the DB_DSN environment variable.
+// Panics at startup if the variable is not set.
+func MySQLDSN() string {
+	dsn := os.Getenv("DB_DSN")
+	if dsn == "" {
+		panic("DB_DSN environment variable is required")
+	}
+	return dsn
+}

--- a/easy_note/pkg/consts/consts.go
+++ b/easy_note/pkg/consts/consts.go
@@ -15,7 +15,10 @@
 
 package consts
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 const (
 	NoteTableName   = "note"
@@ -35,21 +38,23 @@ const (
 )
 
 // SecretKey returns the JWT signing key from the JWT_SECRET_KEY environment variable.
-// Panics at startup if the variable is not set, preventing silent insecure defaults.
+// Terminates at startup if the variable is not set, preventing silent insecure defaults.
 func SecretKey() string {
 	key := os.Getenv("JWT_SECRET_KEY")
 	if key == "" {
-		panic("JWT_SECRET_KEY environment variable is required. Generate a strong random key.")
+		fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET_KEY is not set. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
 	}
 	return key
 }
 
 // MySQLDSN returns the database connection string from the DB_DSN environment variable.
-// Panics at startup if the variable is not set.
+// Terminates at startup if the variable is not set.
 func MySQLDSN() string {
 	dsn := os.Getenv("DB_DSN")
 	if dsn == "" {
-		panic("DB_DSN environment variable is required")
+		fmt.Fprintf(os.Stderr, "fatal: DB_DSN is not set. Example: user:password@tcp(localhost:3306)/dbname?charset=utf8&parseTime=True&loc=Local\n")
+		os.Exit(1)
 	}
 	return dsn
 }


### PR DESCRIPTION
The easy_note demo has two hardcoded credentials in its constants file: a JWT signing key and a MySQL DSN with username and password.

## What was there

**easy_note/pkg/consts/consts.go:21,28:**

```go
const (
    SecretKey       = "secret key"
    MySQLDefaultDSN = "gorm:gorm@tcp(localhost:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
)
```

The JWT signing key "secret key" is used in cmd/api/mw/jwt.go:

```go
Key: []byte(consts.SecretKey),
```

The DSN "gorm:gorm@tcp(...)" exposes the database username and password. Anyone reading the public repo can:

1. Forge JWT tokens with "secret key" and authenticate as any user
2. Connect to the MySQL database with gorm:gorm credentials

## What changed

Replaced constants with functions that read from env vars, exiting cleanly if not set:

```go
func SecretKey() string {
    key := os.Getenv("JWT_SECRET_KEY")
    if key == "" {
        fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET_KEY is not set. Generate one with: openssl rand -base64 32
")
        os.Exit(1)
    }
    return key
}

func MySQLDSN() string {
    dsn := os.Getenv("DB_DSN")
    if dsn == "" {
        fmt.Fprintf(os.Stderr, "fatal: DB_DSN is not set
")
        os.Exit(1)
    }
    return dsn
}
```

Call site updated from consts.SecretKey to consts.SecretKey().

---

CWE-798